### PR TITLE
task(issue-21): update authorino-operator to track release-v0.23.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "authorino-operator"]
 	path = authorino-operator
 	url = https://github.com/Kuadrant/authorino-operator
-	branch = main
+	branch = release-v0.23.1


### PR DESCRIPTION
Update the authorino-operator submodule configuration to track the release-v0.23.1 branch instead of main.

Part of the downstream submodule alignment effort.
Related: Kuadrant/sector#21