### PR TITLE
feat: enable FIPS compliance check in bundle build pipeline

### DIFF
--- a/Containerfile.authorino-operator
+++ b/Containerfile.authorino-operator
@@ -35,7 +35,8 @@ ENV DIRTY=${DIRTY:-unknown}
 
 # Build Authorino Operator
 RUN echo "Building with GIT_SHA=${GIT_SHA}, DIRTY=${DIRTY}" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a \
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a \
+    -tags strictfipsruntime \
     -ldflags "-X main.version=${AUTHORINO_OPERATOR_VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" \
     -o ${BINARY_NAME} main.go
 


### PR DESCRIPTION
## Summary

Add FIPS compliance check to the operator bundle build pipeline using the official Konflux `fips-operator-bundle-check-oci-ta` task.

## Changes

- `.tekton/bundle-build-pipeline.yaml` — adds `fips-operator-bundle-check-oci-ta` task after `build-image-index`, gated on `skip-checks: false`. Uses the official task bundle from `quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1`
- `.tekton/multi-arch-build-pipeline.yaml` — removes the previous inline `fips-check` task that used the git resolver and RHOAI-owned images

The task scans `relatedImages` from the operator bundle image using `check-payload` to verify FIPS compliance. It only runs on bundle images that declare `features.operators.openshift.io/fips-compliant: "true"` or require an OpenShift subscription.

## Test plan

- [ ] Konflux bundle PR build passes including the new `fips-operator-bundle-check-oci-ta` task
- [ ] `check-payload` reports a successful result for all related images