### PR TITLE
fix: add images-mirror-set.yaml for FIPS check to scan unreleased images

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: authorino-operator-mirrors
+spec:
+  imageDigestMirrors:
+    - source: registry.redhat.io/rhcl-1/authorino-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-authorino-operator
+    - source: registry.redhat.io/rhcl-1/authorino-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-authorino
+    - source: registry.stage.redhat.io/rhcl-1/authorino-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-authorino-operator
+    - source: registry.stage.redhat.io/rhcl-1/authorino-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/api-management-tenant/rhcl-1-4-authorino


### PR DESCRIPTION
Adds `.tekton/images-mirror-set.yaml` required by `fips-operator-bundle-check-oci-ta` to map unreleased `registry.redhat.io` and `registry.stage.redhat.io` pullspecs to their `quay.io/redhat-user-workloads` equivalents so the FIPS check can scan images before they are released.